### PR TITLE
fix: when running khalorg from a venv, the global khal executable is …

### DIFF
--- a/src/khalorg/khal/calendar.py
+++ b/src/khalorg/khal/calendar.py
@@ -1,4 +1,6 @@
 import logging
+from os.path import dirname, join
+import sys
 from datetime import date, datetime
 from typing import Callable, Iterable, TypedDict, Union
 
@@ -84,8 +86,9 @@ class Calendar:
         """
         path_config: Union[str, None] = find_configuration_file()
 
-        new_item_args: list = ["python3", "-m", "khal", "new"]
-        list_args: list = ["python3", "-m", "khal", "list", "-df", ""]
+        khal_bin: str = join(dirname(sys.executable), 'khal')
+        new_item_args: list = [khal_bin, "new"]
+        list_args: list = [khal_bin, "list", "-df", ""]
 
         self._collection: CalendarCollection
         self._new_item: Callable = subprocess_callback(new_item_args)

--- a/src/khalorg/khal/helpers.py
+++ b/src/khalorg/khal/helpers.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from datetime import date, datetime
 from subprocess import STDOUT, CalledProcessError, check_output
 from typing import Callable
@@ -72,7 +71,7 @@ def subprocess_callback(cmd: list) -> Callable:
 
 def try_check_output(args: list) -> bytes:
     try:
-        return check_output(args, stderr=STDOUT, executable=sys.executable)
+        return check_output(args, stderr=STDOUT)
     except CalledProcessError as error:
         error_message: str = (
             f"The following arguments were sent to khal:\n\n{' '.join(args)}"


### PR DESCRIPTION
…sometimes used instead of the venv its khal executable. (#4)